### PR TITLE
Read kg refactor

### DIFF
--- a/cat_merge/file_utils.py
+++ b/cat_merge/file_utils.py
@@ -3,6 +3,7 @@ import os
 import tarfile
 from pathlib import Path
 import pandas as pd
+from grape import Graph  # type: ignore
 from typing import IO, List, Optional, Tuple, Union
 
 from pandas import DataFrame
@@ -121,6 +122,34 @@ def read_kg(source: str = None,
 
     kg = MergedKG(nodes, edges, duplicate_nodes, dangling_edges)
     return kg
+
+
+def load_graph(name: str, version: str, edges_path: str,
+               nodes_path: str) -> Graph:
+    """
+    Load a graph with Ensmallen (from grape).
+    :param name: OBO name
+    :param version: OBO version
+    :param edges_path: path to edge file
+    :param nodes_path: path to node file
+    :return: ensmallen Graph object
+    """
+
+    loaded_graph = Graph.from_csv(name=f"{name}_version_{version}",
+                                  edge_path=edges_path,
+                                  sources_column="subject",
+                                  destinations_column="object",
+                                  edge_list_header=True,
+                                  edge_list_separator="\t",
+                                  node_path=nodes_path,
+                                  nodes_column="id",
+                                  node_list_header=True,
+                                  node_list_separator="\t",
+                                  directed=False,
+                                  verbose=True
+                                  )
+
+    return loaded_graph
 
 
 def write(kg: MergedKG, name: str, output_dir: str):

--- a/cat_merge/file_utils.py
+++ b/cat_merge/file_utils.py
@@ -90,9 +90,13 @@ def read_kg(source: str = None,
             [node_file], [edge_file] = get_files(source)
             nodes = read_df(node_file, add_source_col, node_file)
             edges = read_df(edge_file, add_source_col, edge_file)
-            [duplicate_node_file], [dangling_edge_file] = get_files(source, duplicate_node_match, dangling_edge_match)
-            duplicate_nodes = read_df(duplicate_node_file, add_source_col, node_file)
-            dangling_edges = read_df(dangling_edge_file, add_source_col, node_file)
+            duplicate_files = get_files(source, duplicate_node_match, dangling_edge_match)
+            if len(duplicate_files[0]) == 1:
+                [duplicate_node_file] = duplicate_files[0]
+                duplicate_nodes = read_df(duplicate_node_file, add_source_col, node_file)
+            if len(duplicate_files[0]) == 1:
+                [dangling_edge_file] = duplicate_files[1]
+                dangling_edges = read_df(dangling_edge_file, add_source_col, node_file)
         elif tarfile.is_tarfile(source):
             tar = tarfile.open(source, "r:*")
             [nodes] = read_tar_dfs(tar, node_match, add_source_col)

--- a/cat_merge/file_utils.py
+++ b/cat_merge/file_utils.py
@@ -101,9 +101,12 @@ def read_kg(source: str = None,
             tar = tarfile.open(source, "r:*")
             [nodes] = read_tar_dfs(tar, node_match, add_source_col)
             [edges] = read_tar_dfs(tar, edge_match, add_source_col)
-            [duplicate_nodes] = read_tar_dfs(tar, edge_match, add_source_col)
-            [dangling_edges] = read_tar_dfs(tar, edge_match, add_source_col)
-            # [nodes], [edges] = read_tar(source, node_match, edge_match, add_source_col)
+            tar_duplicate_nodes = read_tar_dfs(tar, duplicate_node_match, add_source_col)
+            if len(tar_duplicate_nodes) == 1:
+                [duplicate_nodes] = tar_duplicate_nodes
+            tar_dangling_edges = read_tar_dfs(tar, dangling_edge_match, add_source_col)
+            if len(tar_dangling_edges) == 1:
+                [dangling_edges] = tar_dangling_edges
         else:
             raise ValueError("source is not an archive or directory")
     elif node_file is not None and edge_file is not None:

--- a/cat_merge/qc_utils.py
+++ b/cat_merge/qc_utils.py
@@ -159,34 +159,6 @@ def get_difference(a: Union[List, pd.Series], b: Union[List, pd.Series]) -> Unio
     return s if type(a) is list else pd.Series(s, dtype=a.dtype, name=a.name)
 
 
-def load_graph(name: str, version: str, edges_path: str,
-               nodes_path: str) -> Graph:
-    """
-    Load a graph with Ensmallen (from grape).
-    :param name: OBO name
-    :param version: OBO version
-    :param edges_path: path to edge file
-    :param nodes_path: path to node file
-    :return: ensmallen Graph object
-    """
-
-    loaded_graph = Graph.from_csv(name=f"{name}_version_{version}",
-                                  edge_path=edges_path,
-                                  sources_column="subject",
-                                  destinations_column="object",
-                                  edge_list_header=True,
-                                  edge_list_separator="\t",
-                                  node_path=nodes_path,
-                                  nodes_column="id",
-                                  node_list_header=True,
-                                  node_list_separator="\t",
-                                  directed=False,
-                                  verbose=True
-                                  )
-
-    return loaded_graph
-
-
 def create_stats_report(g: Graph) -> List[Dict]:
     node_count = g.get_number_of_nodes()
     edge_count = g.get_number_of_edges()

--- a/tests/unit/test_col_to_yaml.py
+++ b/tests/unit/test_col_to_yaml.py
@@ -1,0 +1,23 @@
+import pytest
+from tests.test_utils import string_df
+from cat_merge.qc_utils import col_to_yaml
+from typing import List
+import pandas as pd
+
+
+@pytest.fixture
+def series1() -> pd.Series:
+    S = pd.Series(['this', 'that', 'the'])
+    return S
+
+
+def test_col_to_yaml_length(series1):
+    test_series = col_to_yaml(series1)
+    assert (len(test_series) == 3)
+
+
+def test_col_to_yaml_order(series1):
+    test_series = col_to_yaml(series1)
+    assert (test_series[0] == 'that')
+    assert (test_series[1] == 'the')
+    assert (test_series[2] == 'this')

--- a/tests/unit/test_get_difference.py
+++ b/tests/unit/test_get_difference.py
@@ -1,6 +1,4 @@
 import pytest
-# from tests.test_utils import string_df
-# from cat_merge.merge_utils import concat_dataframes
 from cat_merge.qc_utils import get_difference
 from typing import List
 import pandas as pd
@@ -49,39 +47,3 @@ def test_series_difference_order(series1, series2):
     test_series = get_difference(series1, series2)
     assert (test_series[0] == 'that')
     assert (test_series[1] == 'this')
-
-
-# def test_length(dataframes):
-#     df = concat_dataframes(list(dataframes))
-#     assert(len(df) == 4)
-#
-#
-# def test_columns(dataframes):
-#     df = concat_dataframes(list(dataframes))
-#     assert(list(df.columns) == ['id', 'category', 'name', 'xrefs', 'synonyms'])
-#
-#
-# @pytest.fixture
-# def one_empty_dataframe() -> Tuple[DataFrame, DataFrame]:
-#     A = u"""\
-#     id      category name
-#     Gene:1  Gene     FGF8
-#     Gene:2  Gene     PAX2
-#     """
-#
-#     B = u"""\
-#     id         category    name
-#     """
-#
-#     return string_df(A), string_df(B)
-#
-#
-# def test_empty_df(one_empty_dataframe):
-#     df = concat_dataframes(list(one_empty_dataframe))
-#     assert(len(df) == 2)
-#
-#
-# def test_null_dataframe(dataframes):
-#     df = concat_dataframes([dataframes[0], None])
-#     assert(len(df) == 2)
-#     assert(list(df.columns) == ['id', 'category', 'name', 'xrefs'])

--- a/tests/unit/test_get_difference.py
+++ b/tests/unit/test_get_difference.py
@@ -1,0 +1,86 @@
+import pytest
+# from tests.test_utils import string_df
+# from cat_merge.merge_utils import concat_dataframes
+from cat_merge.qc_utils import get_difference
+from typing import List
+import pandas as pd
+
+
+@pytest.fixture
+def list1() -> List[str]:
+    L = ['this', 'that', 'the']
+    return L
+
+
+@pytest.fixture
+def list2() -> List[str]:
+    L = ['the', 'other']
+    return L
+
+
+def test_list_difference_length(list1, list2):
+    test_list = get_difference(list1, list2)
+    assert (len(test_list) == 2)
+
+
+def test_list_difference_order(list1, list2):
+    test_list = get_difference(list1, list2)
+    assert (test_list == ['that', 'this'])
+
+
+@pytest.fixture
+def series1() -> pd.Series:
+    S = pd.Series(['this', 'that', 'the'])
+    return S
+
+
+@pytest.fixture
+def series2() -> pd.Series:
+    S = pd.Series(['the', 'other'])
+    return S
+
+
+def test_series_difference_length(series1, series2):
+    test_list = get_difference(series1, series2)
+    assert (len(test_list) == 2)
+
+
+def test_series_difference_order(list1, list2):
+    test_list = get_difference(list1, list2)
+    assert (test_list == ['that', 'this'])
+
+
+# def test_length(dataframes):
+#     df = concat_dataframes(list(dataframes))
+#     assert(len(df) == 4)
+#
+#
+# def test_columns(dataframes):
+#     df = concat_dataframes(list(dataframes))
+#     assert(list(df.columns) == ['id', 'category', 'name', 'xrefs', 'synonyms'])
+#
+#
+# @pytest.fixture
+# def one_empty_dataframe() -> Tuple[DataFrame, DataFrame]:
+#     A = u"""\
+#     id      category name
+#     Gene:1  Gene     FGF8
+#     Gene:2  Gene     PAX2
+#     """
+#
+#     B = u"""\
+#     id         category    name
+#     """
+#
+#     return string_df(A), string_df(B)
+#
+#
+# def test_empty_df(one_empty_dataframe):
+#     df = concat_dataframes(list(one_empty_dataframe))
+#     assert(len(df) == 2)
+#
+#
+# def test_null_dataframe(dataframes):
+#     df = concat_dataframes([dataframes[0], None])
+#     assert(len(df) == 2)
+#     assert(list(df.columns) == ['id', 'category', 'name', 'xrefs'])

--- a/tests/unit/test_get_intersection.py
+++ b/tests/unit/test_get_intersection.py
@@ -1,7 +1,7 @@
 import pytest
 # from tests.test_utils import string_df
 # from cat_merge.merge_utils import concat_dataframes
-from cat_merge.qc_utils import get_difference
+from cat_merge.qc_utils import get_intersection
 from typing import List
 import pandas as pd
 
@@ -18,14 +18,14 @@ def list2() -> List[str]:
     return L
 
 
-def test_list_difference_length(list1, list2):
-    test_list = get_difference(list1, list2)
-    assert (len(test_list) == 2)
+def test_list_intersection_length(list1, list2):
+    test_series = get_intersection(list1, list2)
+    assert (len(test_series) == 1)
 
 
-def test_list_difference_order(list1, list2):
-    test_list = get_difference(list1, list2)
-    assert (test_list == ['that', 'this'])
+def test_list_intersection_order(list1, list2):
+    test_series = get_intersection(list1, list2)
+    assert (test_series == ['the'])
 
 
 @pytest.fixture
@@ -40,15 +40,14 @@ def series2() -> pd.Series:
     return S
 
 
-def test_series_difference_length(series1, series2):
-    test_series = get_difference(series1, series2)
-    assert (len(test_series) == 2)
+def test_series_intersection_length(series1, series2):
+    test_series = get_intersection(series1, series2)
+    assert (len(test_series) == 1)
 
 
-def test_series_difference_order(series1, series2):
-    test_series = get_difference(series1, series2)
-    assert (test_series[0] == 'that')
-    assert (test_series[1] == 'this')
+def test_series_intersection_order(list1, list2):
+    test_series = get_intersection(list1, list2)
+    assert (test_series[0] == 'the')
 
 
 # def test_length(dataframes):

--- a/tests/unit/test_get_intersection.py
+++ b/tests/unit/test_get_intersection.py
@@ -1,6 +1,4 @@
 import pytest
-# from tests.test_utils import string_df
-# from cat_merge.merge_utils import concat_dataframes
 from cat_merge.qc_utils import get_intersection
 from typing import List
 import pandas as pd
@@ -49,38 +47,3 @@ def test_series_intersection_order(list1, list2):
     test_series = get_intersection(list1, list2)
     assert (test_series[0] == 'the')
 
-
-# def test_length(dataframes):
-#     df = concat_dataframes(list(dataframes))
-#     assert(len(df) == 4)
-#
-#
-# def test_columns(dataframes):
-#     df = concat_dataframes(list(dataframes))
-#     assert(list(df.columns) == ['id', 'category', 'name', 'xrefs', 'synonyms'])
-#
-#
-# @pytest.fixture
-# def one_empty_dataframe() -> Tuple[DataFrame, DataFrame]:
-#     A = u"""\
-#     id      category name
-#     Gene:1  Gene     FGF8
-#     Gene:2  Gene     PAX2
-#     """
-#
-#     B = u"""\
-#     id         category    name
-#     """
-#
-#     return string_df(A), string_df(B)
-#
-#
-# def test_empty_df(one_empty_dataframe):
-#     df = concat_dataframes(list(one_empty_dataframe))
-#     assert(len(df) == 2)
-#
-#
-# def test_null_dataframe(dataframes):
-#     df = concat_dataframes([dataframes[0], None])
-#     assert(len(df) == 2)
-#     assert(list(df.columns) == ['id', 'category', 'name', 'xrefs'])

--- a/tests/unit/test_get_namespace.py
+++ b/tests/unit/test_get_namespace.py
@@ -1,12 +1,16 @@
 import pytest
 from cat_merge.qc_utils import get_namespace
+import pandas as pd
 
 
 @pytest.fixture
-def id_str() -> str:
-    return 'TEST:TEST-GENE-010000-1'
+def series1() -> pd.Series:
+    S = pd.Series(['TEST:TEST-GENE-010000-1', 'TEST2:TEST-GENE-010000-2', 'TEST3:TEST-GENE-010002-1'])
+    return S
 
 
-def test_get_namespace(id_str):
-    test_namespace = get_namespace(id_str)
-    assert (test_namespace == 'TEST')
+def test_get_namespace_length(series1):
+    test_namespace = get_namespace(series1)
+    assert (len(test_namespace) == 3)
+
+

--- a/tests/unit/test_get_namespace.py
+++ b/tests/unit/test_get_namespace.py
@@ -14,3 +14,8 @@ def test_get_namespace_length(series1):
     assert (len(test_namespace) == 3)
 
 
+def test_get_namespace_order(series1):
+    test_namespace = get_namespace(series1)
+    assert (test_namespace[0] == 'TEST')
+    assert (test_namespace[1] == 'TEST2')
+    assert (test_namespace[2] == 'TEST3')

--- a/tests/unit/test_get_namespace.py
+++ b/tests/unit/test_get_namespace.py
@@ -1,9 +1,5 @@
 import pytest
-# from tests.test_utils import string_df
-# from cat_merge.merge_utils import concat_dataframes
 from cat_merge.qc_utils import get_namespace
-from typing import List
-import pandas as pd
 
 
 @pytest.fixture

--- a/tests/unit/test_get_namespace.py
+++ b/tests/unit/test_get_namespace.py
@@ -1,0 +1,16 @@
+import pytest
+# from tests.test_utils import string_df
+# from cat_merge.merge_utils import concat_dataframes
+from cat_merge.qc_utils import get_namespace
+from typing import List
+import pandas as pd
+
+
+@pytest.fixture
+def id_str() -> str:
+    return 'TEST:TEST-GENE-010000-1'
+
+
+def test_get_namespace(id_str):
+    test_namespace = get_namespace(id_str)
+    assert (test_namespace == 'TEST')


### PR DESCRIPTION
Re-write readKG to include duplicate nodes and dangling edges and properly handle when these files are missing.
We need these files when we are re-generating QC reports and they may need to come from a different source.